### PR TITLE
bug(bare): address possible hard to read text colors

### DIFF
--- a/bare
+++ b/bare
@@ -64,12 +64,12 @@ case $1 in
 			# mostly for Macs running zsh by default
 			export BASH_SILENCE_DEPRECATION_WARNING=1
 
-			GREEN='\\033[0;32m'
-			YELLOW='\\033[0;33m'
-			GRAY='\\033[2;37m'
+			GREEN='\\033[40;32m'
+			YELLOW='\\033[40;33m'
+			GRAY='\\033[40;37m'
 			RESET='\\033[0m'
 
-			PS1="🐻 \[\${GREEN}\]\$(basename \$(pwd)) \[\${YELLOW}\]> \[\${RESET}\]"
+			PS1="\[\${GREEN}\] 🐻 \$(basename \$(pwd)) \[\${YELLOW}\]> \[\${RESET}\]"
 
 			printf "\n\${GRAY}entering bare terminal. type exit when ready to leave.\${RESET}\n"
 


### PR DESCRIPTION
### This PR deals with a minor style issue of conflicting text/background colors.
It addresses [this issue](https://github.com/matthewlarkin/bare.sh/issues/2)


The style of the bare text from bare clashes with my light background:

<img width="672" alt="Screen Shot 2024-08-09 at 9 38 31 AM" src="https://github.com/user-attachments/assets/c03293c3-8c09-4526-9942-a64ee14e6c7a">

Ideally we could change the entire terminal background when bare is active, but it seems that is [not possible?](https://unix.stackexchange.com/questions/361485/change-terminal-background-from-bash-script-in-platform-desktop-environment-ind?newreg=0e9c5328f02a461f8c8f7cb9950b3e5b)

So my temporary and not very beautiful fix is to add a background to that specific text and the prompt:

<img width="851" alt="Screen Shot 2024-08-09 at 3 53 21 PM" src="https://github.com/user-attachments/assets/db883caf-59d4-4a53-8cd2-b98ed0614157">


I honestly thought this would be an easy thing to start out with, but as always what appears easy is in fact layers and layers of hard to do. 

Curious to hear your thoughts and possible alternatives to this. 



