### PR TITLE
Update ux for openai to include space and color

### DIFF
--- a/bare
+++ b/bare
@@ -64,12 +64,12 @@ case $1 in
 			# mostly for Macs running zsh by default
 			export BASH_SILENCE_DEPRECATION_WARNING=1
 
-			GREEN='\\033[40;32m'
-			YELLOW='\\033[40;33m'
-			GRAY='\\033[40;37m'
+			GREEN='\\033[0;32m'
+			YELLOW='\\033[0;33m'
+			GRAY='\\033[2;37m'
 			RESET='\\033[0m'
 
-			PS1="\[\${GREEN}\] 🐻 \$(basename \$(pwd)) \[\${YELLOW}\]> \[\${RESET}\]"
+			PS1="🐻 \[\${GREEN}\]\$(basename \$(pwd)) \[\${YELLOW}\]> \[\${RESET}\]"
 
 			printf "\n\${GRAY}entering bare terminal. type exit when ready to leave.\${RESET}\n"
 

--- a/bare
+++ b/bare
@@ -64,12 +64,12 @@ case $1 in
 			# mostly for Macs running zsh by default
 			export BASH_SILENCE_DEPRECATION_WARNING=1
 
-			GREEN='\\033[0;32m'
-			YELLOW='\\033[0;33m'
-			GRAY='\\033[2;37m'
+			GREEN='\\033[40;32m'
+			YELLOW='\\033[40;33m'
+			GRAY='\\033[40;37m'
 			RESET='\\033[0m'
 
-			PS1="🐻 \[\${GREEN}\]\$(basename \$(pwd)) \[\${YELLOW}\]> \[\${RESET}\]"
+			PS1="\[\${GREEN}\] 🐻 \$(basename \$(pwd)) \[\${YELLOW}\]> \[\${RESET}\]"
 
 			printf "\n\${GRAY}entering bare terminal. type exit when ready to leave.\${RESET}\n"
 

--- a/openai
+++ b/openai
@@ -140,7 +140,15 @@ case "$1" in
 			recins -t ThreadMessage .var/bare.rec -f Thread -v "$thread_title" -f Author -v "${assistant_name-Assistant}" -f Contents -v "$response"
 		}
 
-		echo "$response"
+		GRAY='\033[40;37m'
+		RESET='\033[0m' 
+		
+		# Pipe the response through a sed to replace each new line start with a tab
+		formatted_response=$(echo "$response" | sed 's/^/\t/')
+
+		echo -e "${GRAY}\n\n$formatted_response"
+		echo -e "${RESET}\n"
+
 
         ;;
 


### PR DESCRIPTION
This PR updates the openai script to add a simple background and spacing for the chat's response.

In regards to [this issue](https://github.com/matthewlarkin/bare.sh/issues/3)

It 
-Pipes the response through a sed command that replaces the "^" begin line character with "\t" a tab character
-Adds a simple background and text color to the response to make it stand out from remaining terminal text

<img width="455" alt="Screen Shot 2024-08-09 at 10 07 49 PM" src="https://github.com/user-attachments/assets/0124b77f-74c1-42eb-8d3e-d208f8a2d8f3">

**NOTE** 
Is there a more convenient way to store reused variables like GRAY and RESET somewhere globally so we might not have to re-code them in different scripts? Or is it better to have them function in isolation?

<img width="275" alt="Screen Shot 2024-08-09 at 10 08 05 PM" src="https://github.com/user-attachments/assets/480fb85c-98f5-4eab-acee-5423cf533eae">


